### PR TITLE
add AnthropicAgent

### DIFF
--- a/motto/agents/__init__.py
+++ b/motto/agents/__init__.py
@@ -2,3 +2,4 @@ from .agent import Response, Agent, EchoAgent
 from .metta_agent import MettaAgent, DialogAgent
 from .gpt_agent import ChatGPTAgent
 from .retrieval_agent import RetrievalAgent
+from .anthropic_agent import AnthropicAgent

--- a/motto/agents/anthropic_agent.py
+++ b/motto/agents/anthropic_agent.py
@@ -36,9 +36,6 @@ class AnthropicAgent(Agent):
         return response
 
     def __call__(self, messages, functions=[]):
-        print("-------------------")
-        print("call AnthropicAgent: ", messages)
-        print("------------------")
         if functions == []:
             response = self.run_insists(model=self._model,
                 messages=get_messages_no_system(messages),

--- a/motto/agents/anthropic_agent.py
+++ b/motto/agents/anthropic_agent.py
@@ -1,0 +1,51 @@
+import anthropic
+from .agent import Agent,Response
+import httpx
+import os
+import logging
+import time
+
+
+# FIXME: A more flexible was to setup proxy?
+proxy=os.environ.get('OPENAI_PROXY')
+client = anthropic.Anthropic() if proxy is None else \
+         anthropic.Anthropic(http_client=httpx.Client(proxies=proxy))
+
+def get_system(messages):
+    return "\n".join(m["content"] for m in messages if m["role"] == "system")
+
+def get_messages_no_system(messages):
+    return [m for m in messages if m["role"] != "system"]
+
+class AnthropicAgent(Agent):
+
+    def __init__(self, model="claude-3-opus-20240229"):
+        self._model = model
+        self.log = logging.getLogger(__name__ + '.' + type(self).__name__)
+
+    def run_insists(self, **kwargs):
+        response = None
+        while response is None:
+            try:
+                response = client.messages.create(**kwargs)
+            except anthropic.RateLimitError as e:
+                self.log.debug(f"Error: {e}")
+                self.log.debug(f"Error: {type(e)}")
+                self.log.debug("RETRY!")
+                time.sleep(10)
+        return response
+
+    def __call__(self, messages, functions=[]):
+        print("-------------------")
+        print("call AnthropicAgent: ", messages)
+        print("------------------")
+        if functions == []:
+            response = self.run_insists(model=self._model,
+                messages=get_messages_no_system(messages),
+                system = get_system(messages),
+                max_tokens = 1024,
+                temperature=0,
+                timeout = 15)
+        else:
+            raise Exception("We do not support functional calls with Anthropic models")
+        return Response(response.content[0].text)

--- a/motto/llm_gate.py
+++ b/motto/llm_gate.py
@@ -253,6 +253,7 @@ def llmgate_atoms(metta):
         r"llm": llmAtom,
         r"atom2msg": msgAtom,
         r"chat-gpt": chatGPTAtom,
+        r"anthropic-agent": OperationAtom('anthropic-agent', AnthropicAgent),
         r"EchoAgent": echoAgentAtom,
         r"metta-chat": mettaChatAtom,
         r"retrieval-agent": retrievalAgentAtom,


### PR DESCRIPTION
add AnthropicAgent in order to use claude models. You can replace chat-gpt with anthropic-agent.

```lisp
(llm (Agent (anthropic-agent)) ...)
```
By default it will use the most capable and expensive `claude-3-opus-20240229` you can change it to less expensive model `claude-3-sonnet-20240229` or `claude-3-haiku-20240229` by directly specifying the name of the model.

```lisp
(llm (Agent (anthropic-agent "claude-3-sonnet-20240229")) ...)
```


