### PR TITLE
Tools instead funtions

### DIFF
--- a/examples/test_several_tools_calls.msa
+++ b/examples/test_several_tools_calls.msa
@@ -1,0 +1,48 @@
+!(import! &self motto)
+(= (doc get_current_weather)
+  (Doc
+    (description "Get the current weather for the city")
+    (parameters
+      (location "the city: " ("Tokyo" "New York" "London"))
+    ))
+)
+
+(= (doc get_area)
+  (Doc
+    (description "Get area for the city (km ^ 2)")
+    (parameters
+      (city "the city: " ("Tokyo" "New York" "London"))
+    ))
+)
+
+(= (get_current_weather ($arg) $msgs)
+   (if (== (contains-str $arg "Tokyo") True)
+       "the temperature in Tokyo is 75 fahrenheit"
+       (if (== (contains-str $arg "New York") True)
+           "The temperature in New York is 80 fahrenheit"
+           (concat-str (concat-str "The temperature in " $arg) " is 70 fahrenheit" )
+       )
+  )
+)
+
+(= (get_area ($arg) $msgs)
+   (if (== (contains-str $arg "Tokyo") True)
+       "The area of New York Tokyo is 2194 km^2"
+       (if (== (contains-str $arg "New York") True)
+           "The area of New York  is 778 km^2"
+           (concat-str (concat-str "The area of " $arg) " is 1,572 km^2" )
+       )
+  )
+)
+
+!(llm (Agent (chat-gpt "gpt-3.5-turbo-1106"))
+   (user "What is the current weather in London and tell me the area of New York?")
+   (function get_current_weather)
+   (function get_area)
+)
+
+!(llm (Agent (chat-gpt "gpt-3.5-turbo-1106"))
+   (user "What is the current weather in New York and Tokyo?")
+   (function get_current_weather)
+   (function get_area)
+)

--- a/motto/agents/agent.py
+++ b/motto/agents/agent.py
@@ -1,14 +1,28 @@
-class FunctionCall:
-    def __init__(self, name, arguments):
+class Function:
+    def __init__(self, name, arguments, format=""):
         self.name = name
+        self.forma = format
         self.arguments = arguments
 
+class ToolCall:
+    def __init__(self, id, function, type="function"):
+        self.id = id
+        self.function = function
+        self.type = type
+
 class Response:
-    def __init__(self, content, function_call=None):
+    def __init__(self, content, functions=None):
         self.content = content
-        self.function_call = function_call
+        self.tool_calls = None
+        if functions is not None:
+            k = 1
+            self.tool_calls = []
+            for f in functions:
+                self.tool_calls.append(ToolCall(k, f))
+                k =+ 1
+
     def __repr__(self):
-        return f"Response(content: {self.content}, function_call: {self.function_call})"
+        return f"Response(content: {self.content}, tool_calls: {self.tool_calls})"
 
 
 class Agent:
@@ -27,7 +41,7 @@ class EchoAgent(Agent):
     def __call__(self, messages, functions=[]):
         msg = list(map(lambda m: m['role'] + ' ' + m['content'], messages))
         msg = '\n'.join(msg)
-        fcall = None
+        fcall = [] if len(functions) > 0 else None
         # A mock function call processing for testing purposes
         for f in functions:
             vcall = None
@@ -38,5 +52,5 @@ class EchoAgent(Agent):
                         for v in prop[k]['enum']:
                             if prop[k]['description'] + v in msg:
                                 vcall = {k: v}
-                fcall = FunctionCall(f['name'], vcall)
+                fcall.append(Function(f['name'], vcall))
         return Response(msg, fcall)

--- a/motto/agents/gpt_agent.py
+++ b/motto/agents/gpt_agent.py
@@ -20,11 +20,17 @@ class ChatGPTAgent(Agent):
                 temperature=0,
                 timeout = 15)
         else:
+            tools = []
+            for func in functions:
+                dict_values = {}
+                dict_values["type"] = "function";
+                dict_values["function"] = func
+                tools.append(dict_values)
             response = client.chat.completions.create(model=self._model,
                 messages=messages,
-                functions=functions,
-                function_call="auto",
+                tools=tools,
                 temperature=0,
+                tool_choice="auto",
                 timeout = 15)
         # FIXME? Only one result is supposed now. API can be changed later if it turns out to be needed.
         return response.choices[0].message

--- a/motto/llm_gate.py
+++ b/motto/llm_gate.py
@@ -217,7 +217,7 @@ def llm(metta: MeTTa, *args):
         for tool_call in response.tool_calls :
             fname = tool_call.function.name
             fs = S(fname)
-            args = json.loads(tool_call.function.arguments)
+            args = tool_call.function.arguments if isinstance(tool_call.function.arguments, dict) else json.loads(tool_call.function.arguments)
             args = {} if args is None else \
                 json.loads(args) if isinstance(args, str) else args
             # Here, we check if the arguments should be parsed to MeTTa
@@ -228,7 +228,8 @@ def llm(metta: MeTTa, *args):
                     if func["parameters"]["properties"][k]['metta-type'] == 'Atom':
                         args[k] = metta.parse_single(v)
             result.append(repr(E(fs, to_nested_expr(list(args.values())), msgs_atom)))
-        val = metta.parse_single(f"({' '.join(result)})")
+        res = f"({' '.join(result)})" if len(result) > 1 else result[0]
+        val = metta.parse_single(res)
         return  [val]
     return response.content if isinstance(agent, MettaAgent) else \
            [ValueAtom(response.content)]

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -11,8 +11,7 @@ def run_script(fname):
         return MeTTa().run(f.read())
 
 def test_scripts():
-    process_exceptions(run_script(f"{pwd}/basic_function_call.metta"))
-    process_exceptions(run_script(f"{pwd}/basic_function_call.metta"))
+    process_exceptions(run_script(f"{pwd}/basic_direct_call.metta"))
     process_exceptions(run_script(f"{pwd}/basic_function_call.metta"))
     process_exceptions(run_script(f"{pwd}/basic_script_call.metta"))
     process_exceptions(run_script(f"{pwd}/basic_agent_call.metta"))


### PR DESCRIPTION
OpenAI API has deprecated functions in favor of tools. 
I did not added tool_choice argument described [here](https://cookbook.openai.com/examples/how_to_call_functions_with_chat_models#forcing-the-use-of-specific-functions-or-no-function)

this argument can force the model to use a specific function, but I do not If we need it