### PR TITLE
rename union to sparql_union

### DIFF
--- a/examples/test_sparql.metta
+++ b/examples/test_sparql.metta
@@ -38,7 +38,7 @@
 ;takes into account cases where the occupation is given as a plain string
 
 !(select ((fields ($name $birth)) (where (($person dbo:birthPlace dbr:London) ($person foaf:name $name)
-(union (($person dbo:occupation dbr:Actor) ($person dbp:occupation $occupation)
+(sparql_union (($person dbo:occupation dbr:Actor) ($person dbp:occupation $occupation)
 (filter (or (contains (str $occupation) 'Actor')  (contains (str $occupation) 'Actress') ) )
 ))
 ($person dbo:birthDate $birth)

--- a/motto/sparql_gate/sparql_gate.py
+++ b/motto/sparql_gate/sparql_gate.py
@@ -60,7 +60,7 @@ class ServiceFeatures:
 
 
 class RdfHelper:
-    complex_filters = ["filter_exists", "filter_not_exists", "union", "minus"]
+    complex_filters = ["filter_exists", "filter_not_exists", "sparql_union", "minus"]
     binary_operations_dict = {"+": "+", "-": "-", "*": "*", "/": "*", "=": "=", "!=": "!=", "<": "<", ">": ">",
                               "<=": "<=", ">=": ">=",
                               "or": "||", "and": "&&", "as": "as"}
@@ -200,7 +200,7 @@ class RdfHelper:
         function = function.lower()
         if hasattr(atom, 'get_children'):
             conditions, is_simple = self.__get_conditions_from_children(atom)
-            if function == "union":
+            if function == "sparql_union":
                 return [ValueAtom("{{" + "} UNION {".join(conditions) + "}}")]
             # if function is limit, order by, offset, ...
             elif function in RdfHelper.output_options_functions:
@@ -268,8 +268,8 @@ def sql_space_atoms():
             OperationObject('set-sparql-service-type', lambda a: helper.set_service_type(a), unwrap=False)),
         'filter':
             OperationAtom('filter', lambda a: helper.filter(a), type_names=['Atom', 'Atom'], unwrap=False),
-        'union':
-            G(OperationObject('union', lambda a: helper.collect_conditions(a, "union"), unwrap=False)),
+        'sparql_union':
+            G(OperationObject('sparql_union', lambda a: helper.collect_conditions(a, "sparql_union"), unwrap=False)),
         'filter_not_exists':
             G(OperationObject('filter_not_exists', lambda a: helper.collect_conditions(a, "filter not exists"),
                               unwrap=False)),

--- a/tests/sparql_functions_test.metta
+++ b/tests/sparql_functions_test.metta
@@ -64,9 +64,9 @@ filter ($birth > '1930-01-01'^^xsd:date)}")
     "optional {$X foaf:name $name .
 filter (isLiteral($name))}"
  )
-;test union
+;test sparql_union
 !(assertEqual
-     (union (( $process obo:part_of go:GO_0007165) ($process rdfs:subClassOf go:GO_0007165)))
+     (sparql_union (( $process obo:part_of go:GO_0007165) ($process rdfs:subClassOf go:GO_0007165)))
      "{{$process obo:part_of go:GO_0007165} UNION {$process rdfs:subClassOf go:GO_0007165}}")
 ;test order by
 !(assertEqual


### PR DESCRIPTION
there is "union" grounded function  in metta, so "union" from  sparql_gate is not working